### PR TITLE
Catch nested socket exception

### DIFF
--- a/SharpCifs.STD1.3/Smb/SmbTransport.cs
+++ b/SharpCifs.STD1.3/Smb/SmbTransport.cs
@@ -14,20 +14,20 @@
 // You should have received a copy of the GNU Lesser General Public
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+using SharpCifs.Netbios;
+using SharpCifs.Util;
+using SharpCifs.Util.Sharpen;
+using SharpCifs.Util.Transport;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using SharpCifs.Netbios;
-using SharpCifs.Util;
-using SharpCifs.Util.Sharpen;
-using SharpCifs.Util.Transport;
 
 namespace SharpCifs.Smb
 {
-    public class SmbTransport : Transport
+	public class SmbTransport : Transport
     {
         internal static readonly byte[] Buf = new byte[0xFFFF];
 
@@ -529,9 +529,18 @@ namespace SharpCifs.Smb
             }
             catch (TransportException te)
             {
-                var local = (IPEndPoint)this.Socket?.LocalEndPoint;
-                var remote = (IPEndPoint)this.Socket?.RemoteEndPoint;
-                
+                IPEndPoint local = null;
+                IPEndPoint remote = null;
+
+                try
+                {
+                    local = (IPEndPoint)this.Socket?.LocalEndPoint;
+                    remote = (IPEndPoint)this.Socket?.RemoteEndPoint;
+                }
+                catch(SocketException)
+                {
+                }
+
                 // IO Exception
                 throw new SmbException($"Failed to connect, {Address}  [ {local?.Address}:{local?.Port} --> {remote?.Address}:{remote?.Port} ]", te);
             }


### PR DESCRIPTION
In order to resolve issues we've been having where
sockets aren't cleaned up properly after this
exception is caught.  Now catching this
within the exception handling and ignoring.